### PR TITLE
Edited makefile to build Zlib from assimp and updated README for cloning

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,8 +5,9 @@ set(CMAKE_CXX_STANDARD 23)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 # Assimp environment variables
 set(ASSIMP_NO_EXPORT ON)
-# Uncomment this line if you haven't installed zlib and want to build it
-# set(ASSIMP_BUILD_ZLIB ON)
+set(ASSIMP_BUILD_ZLIB ON)
+set(BUILD_SHARED_LIBS OFF)
+set(ASSIMP_BUILD_TESTS OFF)
 
 add_subdirectory(libs/glfw)
 add_subdirectory(libs/bgfx.cmake)
@@ -49,16 +50,13 @@ endforeach()
 file(GLOB SOURCES src/*.cpp)
 add_executable(LoadInAbyss ${SOURCES} ${SHADERS_FILES})
 
-# ZLib is required for assimp
-find_package(ZLIB REQUIRED)
-
 target_link_libraries(LoadInAbyss PRIVATE
         glfw
         bgfx
         bimg
         bx
+        zlibstatic
         assimp
-        ${ZLIB_LIBRARIES}
         )
 target_include_directories(LoadInAbyss PRIVATE
         "${PROJECT_BINARY_DIR}"

--- a/README.md
+++ b/README.md
@@ -1,33 +1,24 @@
 # Load in Abyss
 
-Small pure C++ game made in 3 months with friends to learn C++.
+A small, pure C++ game developed over three months in collaboration with friends to learn modern C++.
 
 ## Installation
 
 ```bash
-git clone --recurse-submodules -j2 git@github.com:marcb152/load-in-abyss.git
+git clone git@github.com:marcb152/load-in-abyss.git
 cd load-in-abyss
 git submodule update --init --recursive
 ```
 
-#### Building assimp
-
-```bash
-cd libs/assimp
-cmake CMakeLists.txt -DASSIMP_NO_EXPORT=ON
-cmake --build .
-```
-
 > [!NOTE]
-> The first build might take a while (5 to 10 minutes), but subsequent builds will be faster.
+> The first build might take a while (5 to 10 minutes), but later builds will be faster.
 
 > [!WARNING]
 > Make sure to have the latest version of CMake, (make, gcc, g++) or ninja or Clang installed.
-> You must also have Zlib installed for Assimp to work (or uncomment the line `set(ASSIMP_BUILD_ZLIB ON)` in CMakeFile.txt).
 
 #### Versions used
 
-C++ 23
+C++23
 
 ## Features
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -4,10 +4,9 @@
  * https://github.com/jpcy/bgfx-minimal-example/blob/master/helloworld.cpp
  */
 #include <iostream>
-#include <stdio.h>
+#include <cstdio>
 #include <bx/bx.h>
 #include <bgfx/bgfx.h>
-#include <bgfx/platform.h>
 #include <GLFW/glfw3.h>
 #if BX_PLATFORM_LINUX
 #define GLFW_EXPOSE_NATIVE_WAYLAND


### PR DESCRIPTION
# Description

Configured CMake to build Assimp with Zlib statically. Updated the README to simplify installation instructions.
Solved issues:
- Git clone behaved weirdly on Windows
- Zlib was required to be installed system-wide, which isn't convenient

## Type of change

Please check options that are relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have performed a self-test of my code and it works on my machine ™️
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated build configuration to use a statically built internal zlib and disabled shared library and test builds.
  - Improved C++ header usage and cleaned up unnecessary includes in the main source file.

- **Documentation**
  - Revised README for clarity, simplified setup instructions, and corrected C++ version notation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->